### PR TITLE
점주 정보업데이트 -기존코드수정

### DIFF
--- a/src/main/java/ssginc_kdt_team3/BE/controller/admin/AdminOwnerController.java
+++ b/src/main/java/ssginc_kdt_team3/BE/controller/admin/AdminOwnerController.java
@@ -93,15 +93,15 @@ public class AdminOwnerController {
 //        }
 //    }
 
-    @PostMapping("/update/{id}")
-    public ResponseEntity<String> updateOwner(@PathVariable(name = "id") Long ownerId,
-                                @RequestBody OwnerUpdateDTO ownerUpdateDTO) {
-        try {
-            ownerService.updateOwnerInfo(ownerId,ownerUpdateDTO);
-            return new ResponseEntity<>("업데이트가 성공적으로 처리되었습니다!",HttpStatus.OK);
-        }catch (Exception e){
-
-            return new ResponseEntity<>(e.getMessage(),HttpStatus.BAD_REQUEST);
-        }
+//    @PostMapping("/update/{id}")
+//    public ResponseEntity<String> updateOwner(@PathVariable(name = "id") Long ownerId,
+//                                @RequestBody OwnerUpdateDTO ownerUpdateDTO) {
+//        try {
+//            ownerService.updateOwnerInfo(ownerId,ownerUpdateDTO);
+//            return new ResponseEntity<>("업데이트가 성공적으로 처리되었습니다!",HttpStatus.OK);
+//        }catch (Exception e){
+//
+//            return new ResponseEntity<>(e.getMessage(),HttpStatus.BAD_REQUEST);
+//        }
     }
 }

--- a/src/main/java/ssginc_kdt_team3/BE/controller/owner/OwnerDataController.java
+++ b/src/main/java/ssginc_kdt_team3/BE/controller/owner/OwnerDataController.java
@@ -25,12 +25,14 @@ public class OwnerDataController {
     @Autowired
     private final OwnerFindPwService ser;
 
-    @PostMapping("/privacy")
-    public ResponseEntity<String> updateInfo(@RequestParam("id")long id,@RequestBody OwnerUpdateDTO ownerUpdateDTO) {
-
-        update.updateOwnerInfo(id,ownerUpdateDTO);
-
-        return new ResponseEntity<>("정보 수정이 완료되었습니다!", HttpStatus.OK);
+    @PostMapping("/info/{id}")
+    public ResponseEntity<String> updateInfo(@PathVariable("id")Long id,@RequestBody OwnerUpdateDTO ownerUpdateDTO) {
+        try {
+            update.updateOwnerInfo(id, ownerUpdateDTO);
+            return new ResponseEntity<>("업데이트가 성공적으로 처리되었습니다.",HttpStatus.OK);
+        }catch (Exception e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
         //점주 정보 수정
 
     }


### PR DESCRIPTION
점주 정보업데이트 -기존코드수정

-기존 관리자 점주 상세정보 수정은 주석처리하고, 점주가 점주 상세정보 조회 수정을 컨트롤러 바꾸고 기존 코드를 수정했습니다.